### PR TITLE
feat: render <Show> on the server from initialState

### DIFF
--- a/.changeset/show-ssr-initial-state.md
+++ b/.changeset/show-ssr-initial-state.md
@@ -4,5 +4,5 @@
 
 `<Show>` now renders on the server and during hydration when `initialState` is provided (via `buildClerkProps`), instead of rendering nothing until clerk-js has loaded in the browser. This matches `@clerk/react` and `@clerk/vue` and removes the blank-content flash on full page loads.
 
-- `<Show>` now accepts a `treatPendingAsSignedOut` prop (default `true`), matching the other Clerk SDKs. Sessions with a `pending` status are now treated as signed out unless the prop is set to `false`.
+- `<Show>` now accepts a `treatPendingAsSignedOut` prop (default `true`), matching the other Clerk SDKs. Sessions with a `pending` status are now treated as signed out unless the prop is set to `false`. In SvelteKit, `locals.auth()` applies the same default on the server, so to opt out during SSR as well, build `initialState` with `buildClerkProps(locals.auth({ treatPendingAsSignedOut: false }))`.
 - Because `<Show>` can now render server-side, `when` predicate functions, children, and `fallback` snippets must be safe to run during SSR.

--- a/.changeset/show-ssr-initial-state.md
+++ b/.changeset/show-ssr-initial-state.md
@@ -1,0 +1,8 @@
+---
+'svelte-clerk': minor
+---
+
+`<Show>` now renders on the server and during hydration when `initialState` is provided (via `buildClerkProps`), instead of rendering nothing until clerk-js has loaded in the browser. This matches `@clerk/react` and `@clerk/vue` and removes the blank-content flash on full page loads.
+
+- `<Show>` now accepts a `treatPendingAsSignedOut` prop (default `true`), matching the other Clerk SDKs. Sessions with a `pending` status are now treated as signed out unless the prop is set to `false`.
+- Because `<Show>` can now render server-side, `when` predicate functions, children, and `fallback` snippets must be safe to run during SSR.

--- a/docs/kit/helpers.md
+++ b/docs/kit/helpers.md
@@ -54,3 +54,15 @@ export const load = async ({ locals }) => {
 	};
 };
 ```
+
+Passing `initialState` to `<ClerkProvider>` (which the SvelteKit `ClerkProvider` does automatically from `page.data.initialState`) lets control components like [`<Show>`](/svelte/components#show) render the correct branch on the server and during hydration, before clerk-js has loaded in the browser.
+
+By default, `locals.auth()` treats sessions with a `pending` status as signed out. If you render `<Show treatPendingAsSignedOut={false}>` and want that to hold during SSR as well, pass the same option to `locals.auth()`:
+
+```ts
+export const load = async ({ locals }) => {
+	return {
+		...buildClerkProps(locals.auth({ treatPendingAsSignedOut: false }))
+	};
+};
+```

--- a/docs/svelte/components.md
+++ b/docs/svelte/components.md
@@ -21,6 +21,8 @@ The following [Clerk UI components](https://clerk.com/docs/components/overview) 
 
 The main difference is that the Svelte components use [`Snippets`](https://svelte.dev/docs/svelte/snippet) to render their content.
 
+### `<Show>`
+
 Here's an example of the [`<Show>`](https://clerk.com/docs/react/reference/components/control/show) component with a fallback message:
 
 ```svelte
@@ -36,5 +38,11 @@ Here's an example of the [`<Show>`](https://clerk.com/docs/react/reference/compo
 	</Show>
 </template>
 ```
+
+`<Show>` supports the same `when` conditions as the other Clerk SDKs (`"signed-in"`, `"signed-out"`, an authorization object such as `{ role: 'org:admin' }`, or a `(has) => boolean` predicate), plus an optional `treatPendingAsSignedOut` prop (default `true`) that controls whether sessions with a `pending` status are treated as signed out.
+
+When `initialState` is provided to `<ClerkProvider>` (SvelteKit apps get this from [`buildClerkProps()`](/kit/helpers#buildclerkprops)), `<Show>` renders the correct branch on the server and during hydration, before clerk-js has loaded. Without `initialState`, it renders nothing until clerk-js has loaded. Because of this, `when` predicate functions, children, and `fallback` snippets must be safe to run during SSR.
+
+`<Show>` only controls what is rendered. It is not a security boundary; protect sensitive data in server `load` functions or API routes using [`locals.auth()`](/kit/quickstart#_6-protect-your-pages).
 
 To see list of available props for each components, visit the [Clerk UI components documentation](https://clerk.com/docs/components/overview).

--- a/e2e/demo.test.ts
+++ b/e2e/demo.test.ts
@@ -83,3 +83,76 @@ test('Update Clerk options on the fly', async ({ page, baseURL }) => {
 	await po.page.locator('select').selectOption({ label: 'en' });
 	await expect(po.page.getByText('Welcome back! Please sign in to continue')).toBeVisible();
 });
+
+test.describe('<Show /> server-side rendering', () => {
+	const SIGNED_IN_TEXT = 'You are signed in!';
+	const SIGNED_OUT_TEXT = 'You are not signed in!';
+
+	function collectHydrationIssues(page: Parameters<typeof createPageObjects>[0]['page']) {
+		const issues: string[] = [];
+		page.on('console', (msg) => {
+			if (/hydrat/i.test(msg.text())) issues.push(`console: ${msg.text()}`);
+		});
+		page.on('pageerror', (err) => {
+			if (/hydrat/i.test(err.message)) issues.push(`pageerror: ${err.message}`);
+		});
+		return issues;
+	}
+
+	test('renders signed-out content in the server HTML', async ({ page }) => {
+		const response = await page.request.get('/');
+		expect(response.ok()).toBe(true);
+
+		const html = await response.text();
+		expect(html).toContain(SIGNED_OUT_TEXT);
+		expect(html).not.toContain(SIGNED_IN_TEXT);
+	});
+
+	test('renders signed-in content in the server HTML after sign in', async ({ page, baseURL }) => {
+		const po = createPageObjects({ page, baseURL });
+		await po.page.goToRelative('/sign-in');
+		await po.signIn.waitForMounted();
+		await po.signIn.signInWithEmailAndInstantPassword({
+			email: USER_EMAIL,
+			password: USER_PASSWORD
+		});
+		await po.expect.toBeSignedIn();
+
+		const response = await page.request.get('/');
+		expect(response.ok()).toBe(true);
+
+		const html = await response.text();
+		expect(html).toContain(SIGNED_IN_TEXT);
+		expect(html).not.toContain(SIGNED_OUT_TEXT);
+	});
+
+	test('hydrates without warnings when signed out', async ({ page, baseURL }) => {
+		const po = createPageObjects({ page, baseURL });
+		const issues = collectHydrationIssues(page);
+
+		await po.page.goToAppHome();
+		await po.page.waitForClerkJsLoaded();
+		await po.expect.toBeSignedOut();
+
+		await expect(page.getByText(SIGNED_OUT_TEXT)).toBeVisible();
+		expect(issues).toEqual([]);
+	});
+
+	test('hydrates without warnings when signed in', async ({ page, baseURL }) => {
+		const po = createPageObjects({ page, baseURL });
+		await po.page.goToRelative('/sign-in');
+		await po.signIn.waitForMounted();
+		await po.signIn.signInWithEmailAndInstantPassword({
+			email: USER_EMAIL,
+			password: USER_PASSWORD
+		});
+		await po.expect.toBeSignedIn();
+
+		const issues = collectHydrationIssues(page);
+		await po.page.goToAppHome();
+		await po.page.waitForClerkJsLoaded();
+
+		await expect(page.getByText(SIGNED_IN_TEXT)).toBeVisible();
+		expect(issues).toEqual([]);
+	});
+});

--- a/src/lib/client/control/Show.svelte
+++ b/src/lib/client/control/Show.svelte
@@ -1,29 +1,59 @@
 <script lang="ts">
 	import type {
-		CheckAuthorizationWithCustomPermissions,
+		GetToken,
 		JwtPayload,
-		ShowWhenCondition
+		PendingSessionOptions,
+		ShowWhenCondition,
+		SignOut
 	} from '@clerk/shared/types';
 	import type { Snippet } from 'svelte';
-	import { createCheckAuthorization } from '@clerk/shared/authorization';
+	import { createCheckAuthorization, resolveAuthState } from '@clerk/shared/authorization';
 	import { useClerkContext } from '$lib/context.js';
+	import { errorThrower } from '$lib/errors/errorThrower.js';
+	import { invalidStateError } from '$lib/errors/messages.js';
 
 	const {
 		when,
 		children,
-		fallback
+		fallback,
+		treatPendingAsSignedOut
 	}: {
 		when: ShowWhenCondition;
 		children: Snippet;
 		fallback?: Snippet;
-	} = $props();
+	} & PendingSessionOptions = $props();
 
 	const ctx = useClerkContext();
 
-	const authorized = $derived.by(() => {
-		if (!ctx.isLoaded) return null;
+	// `resolveAuthState` requires these, but <Show> never exposes them.
+	const getToken: GetToken = () => Promise.resolve(null);
+	const signOut: SignOut = () => Promise.resolve();
 
-		const { userId } = ctx.auth;
+	const authorized = $derived.by(() => {
+		const has = createCheckAuthorization({
+			userId: ctx.auth.userId,
+			orgId: ctx.auth.orgId,
+			orgRole: ctx.auth.orgRole,
+			orgPermissions: ctx.auth.orgPermissions,
+			factorVerificationAge: ctx.auth.factorVerificationAge,
+			features: ((ctx.auth.sessionClaims as JwtPayload | undefined)?.fea as string) || '',
+			plans: ((ctx.auth.sessionClaims as JwtPayload | undefined)?.pla as string) || ''
+		});
+
+		// Derived from the auth state rather than `ctx.isLoaded` so that SSR `initialState`
+		// (via `buildClerkProps`) renders the correct branch before clerk-js has loaded.
+		const auth = resolveAuthState({
+			authObject: { ...ctx.auth, has, getToken, signOut },
+			options: { treatPendingAsSignedOut }
+		});
+
+		if (!auth) {
+			return errorThrower.throw(invalidStateError);
+		}
+
+		if (!auth.isLoaded) return null;
+
+		const { userId } = auth;
 
 		if (when === 'signed-out') {
 			return !userId;
@@ -35,21 +65,11 @@
 			return true;
 		}
 
-		const has = createCheckAuthorization({
-			userId,
-			orgId: ctx.auth.orgId,
-			orgRole: ctx.auth.orgRole,
-			orgPermissions: ctx.auth.orgPermissions,
-			factorVerificationAge: ctx.auth.factorVerificationAge,
-			features: ((ctx.auth.sessionClaims as JwtPayload | undefined)?.fea as string) || '',
-			plans: ((ctx.auth.sessionClaims as JwtPayload | undefined)?.pla as string) || ''
-		});
-
 		if (typeof when === 'function') {
-			return when(has);
+			return when(auth.has);
 		}
 
-		return has(when);
+		return auth.has(when);
 	});
 </script>
 


### PR DESCRIPTION
## Summary

`<Show>` gated on `ctx.isLoaded`, the clerk-js script flag, so it rendered nothing during SSR and hydration even when `initialState` from `buildClerkProps` already said who the user is. An app that wraps every page in `<Show when="signed-in">` ships the content in the server HTML and then shows a blank page until clerk-js has loaded and `/v1/client` has returned. That's 1.8–3.3 s to first content on every full page load in the trace that surfaced this.

This gates on `resolveAuthState` from `@clerk/shared` instead, the way `@clerk/react` and `@clerk/vue` do. `isLoaded` is now `false` only when both `userId` and `sessionId` are `undefined`, which is the no-`initialState` case. `ctx.isLoaded`, `<ClerkLoaded>`, and `<ClerkLoading>` keep their clerk-js meaning.

## Changes

- `<Show>` derives its gate from `resolveAuthState` and throws the shared `invalidStateError` on an inconsistent state, matching React and Vue.
- New `treatPendingAsSignedOut` prop (default `true`) for parity with the other SDKs. Pending sessions now take the signed-out branch unless opted out. On the server, `locals.auth()` already defaults the same way, so opting out during SSR also needs `locals.auth({ treatPendingAsSignedOut: false })`; the docs cover this.
- Four e2e tests: raw SSR HTML for the signed-out and signed-in branches, and hydration-warning checks for both. The two SSR tests fail on `main`.
- Docs for `buildClerkProps` and `<Show>`, and a minor changeset.

Verified by hand on a fresh dev instance that a route without `initialState` still renders nothing until clerk-js loads, and that a pending session (forced org selection) takes the signed-out branch on both server and client.

## Not Planned

- e2e coverage for pending sessions and the no-`initialState` path. Both need instance config or a demo route that doesn't exist yet.
- A `useAuth` hook with its own `isLoaded`. Worth its own issue.

## References

- Closes #456
- Earlier discussion in #245
- `@clerk/react` `Show` and `@clerk/vue` `useAuth`, the reference implementations
